### PR TITLE
immutable until you try hard enough

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,20 @@ Unless you, like, really want to.
     >>> t
     SemiMutableSequence([0, 7, 2, 3, 4])
 
+But why should you be limited to a single attempt? Try a few times. If you really want mutability, you have to work for it.
+
+.. code-block:: python
+
+    >>> t = SemiMutableSequence(range(5), times=5)
+    >>> for _ in range(4):
+    ...     try:
+    ...         t[1] = 7
+    ...     except TypeError:
+    ...         pass
+    >>> t[1] = 7
+    >>> t
+    SemiMutableSequence([0, 7, 2, 3, 4])
+
 Magic Numbers are bad. Who could possibly understand what this means?
 
 .. code-block:: python

--- a/datatypes.py
+++ b/datatypes.py
@@ -1,4 +1,4 @@
-from collections import UserDict, UserList
+from collections import UserDict, UserList, defaultdict
 from math import floor
 import random
 
@@ -6,17 +6,18 @@ from number import *
 
 
 class SemiMutableSequence(UserList):
-    def __init__(self, data):
+    def __init__(self, data, times=2):
         super(SemiMutableSequence, self).__init__(data)
-        self._updates = set()
+        self.times = times
+        self._updates = defaultdict(int)
 
     def __setitem__(self, index, value):
         update = (index, value)
-        if update in self._updates:
+        if self._updates[update] >= self.times - 1:
             self.data[index] = value
-            self._updates.discard(update)
+            del self._updates[update]
         else:
-            self._updates.add(update)
+            self._updates[update] += 1
             raise TypeError('{} object does not support item assignment'.format(self.__class__.__name__))
 
     def __repr__(self):

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -293,3 +293,13 @@ class TestSemiMutableSequence(TestUserList):
             self.data[index] = self.new_item
         self.data[index] = self.new_item
         self.assertEqual(self.data[index], self.new_item)
+
+    def test_set_item_n(self):
+        index = 0
+        self.data.times = 3
+        for _ in range(self.data.times - 1):
+            with self.assertRaises(TypeError):
+                self.data[index] = self.new_item
+        # nth time's a charm
+        self.data[index] = self.new_item
+        self.assertEqual(self.data[index], self.new_item)


### PR DESCRIPTION
Loved your lightning talk at PyCon :-)

 But that `SemiMutableSequence` is too opinionated. Why should I be limited to trying assignment once? What if I want to make users try at least 5 times before becoming mutable?

Let's compromise and make it configurable...

```
    >>> t = SemiMutableSequence(range(5), times=5)
    >>> for _ in range(4):
    ...     try:
    ...         t[1] = 7
    ...     except TypeError:
    ...         pass
    >>> t[1] = 17
    >>> t
    SemiMutableSequence([0, 17, 2, 3, 4])
```
